### PR TITLE
Add simple React Todo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # TaskBuddy
-Task Management Application
+
+TaskBuddy is a simple React-based task management application. It provides basic features to add, complete, and remove tasks.
+
+## Getting Started
+
+No build step is required. Simply open `frontend/index.html` in a browser. The page loads React and Babel from CDNs and runs the app.
+
+## Features
+
+- Add tasks using the input field or by pressing **Enter**.
+- Mark tasks as completed.
+- Remove tasks from the list.
+
+This project is a minimal starting point for a Todoist-like application. Feel free to expand upon it with more advanced features such as due dates, labels, or persistent storage.

--- a/frontend/TodoApp.js
+++ b/frontend/TodoApp.js
@@ -1,0 +1,53 @@
+const { useState } = React;
+
+function TodoApp() {
+  const [tasks, setTasks] = useState([]);
+  const [newTask, setNewTask] = useState('');
+
+  const addTask = () => {
+    if (newTask.trim() === '') return;
+    setTasks([...tasks, { text: newTask, completed: false }]);
+    setNewTask('');
+  };
+
+  const toggleTask = (index) => {
+    const updated = tasks.map((t, i) => i === index ? { ...t, completed: !t.completed } : t);
+    setTasks(updated);
+  };
+
+  const removeTask = (index) => {
+    const updated = tasks.filter((_, i) => i !== index);
+    setTasks(updated);
+  };
+
+  return (
+    <div className="app">
+      <h1>TaskBuddy</h1>
+      <div className="new-task">
+        <input
+          type="text"
+          value={newTask}
+          placeholder="Add a task"
+          onChange={(e) => setNewTask(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && addTask()}
+        />
+        <button onClick={addTask}>Add</button>
+      </div>
+      <ul className="task-list">
+        {tasks.map((task, index) => (
+          <li key={index} className={task.completed ? 'completed' : ''}>
+            <input
+              type="checkbox"
+              checked={task.completed}
+              onChange={() => toggleTask(index)}
+            />
+            <span>{task.text}</span>
+            <button onClick={() => removeTask(index)}>X</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<TodoApp />);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TaskBuddy</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div id="root"></div>
+
+  <!-- React and Babel via CDN -->
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+
+  <!-- Our React app -->
+  <script src="TodoApp.js" type="text/babel"></script>
+</body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,45 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f5f5f5;
+  padding: 20px;
+}
+
+.app {
+  max-width: 500px;
+  margin: 0 auto;
+  background: #fff;
+  padding: 20px;
+  border-radius: 4px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+.new-task {
+  display: flex;
+  margin-bottom: 20px;
+}
+
+.new-task input {
+  flex: 1;
+  padding: 8px;
+  margin-right: 8px;
+}
+
+.task-list {
+  list-style: none;
+  padding: 0;
+}
+
+.task-list li {
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.task-list li.completed span {
+  text-decoration: line-through;
+  color: #999;
+}
+
+.task-list li button {
+  margin-left: auto;
+}


### PR DESCRIPTION
## Summary
- build minimal React app under `frontend`
- allow adding, completing, and removing tasks
- document usage in README

## Testing
- `node --version`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_684196b724148330b60bb68e8719714e