### PR TITLE
Group tasks by date with sticky headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # TaskBuddy
-Task Management Application
+
+TaskBuddy is a simple React-based task management application. It lets you add, complete and remove tasks with a polished interface and subtle animations.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+3. Open the provided local URL in your browser to view the app.
+
+## Features
+
+- Add tasks using the input field or by pressing **Enter**.
+- Mark tasks as completed.
+- Remove tasks from the list.
+- Tasks are grouped under a sticky date header so the date remains visible while scrolling.
+- Sleek styling and subtle animations enhance usability.
+
+This project is a minimal starting point for a Todoist-like application. Feel free to expand upon it with more advanced features such as due dates, labels, or persistent storage.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet" />
+    <title>TaskBuddy</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "taskbuddy",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,108 @@
+.app {
+  max-width: 500px;
+  margin: 0 auto;
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+  animation: fade-in 0.4s ease;
+}
+
+.new-task {
+  display: flex;
+  margin-bottom: 20px;
+}
+
+.new-task input {
+  flex: 1;
+  padding: 10px;
+  margin-right: 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  transition: border 0.3s;
+}
+
+.new-task input:focus {
+  border-color: #42a5f5;
+  outline: none;
+}
+
+.task-list {
+  list-style: none;
+  padding: 0;
+}
+
+.task-group {
+  margin-bottom: 20px;
+}
+
+.task-group-header {
+  position: sticky;
+  top: 0;
+  background: #f0f0f0;
+  padding: 6px 10px;
+  font-weight: 500;
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+
+.task-list li {
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+  background: #fafafa;
+  padding: 10px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  animation: slide-in 0.3s ease;
+}
+
+.task-list li.completed span {
+  text-decoration: line-through;
+  color: #999;
+  transition: color 0.3s;
+}
+
+.task-list li button {
+  margin-left: auto;
+  background: transparent;
+  border: none;
+  color: #e57373;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+
+button {
+  padding: 10px 16px;
+  border: none;
+  background: #42a5f5;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+button:hover {
+  background: #1e88e5;
+}
+
+@keyframes slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import './App.css';
+
+function App() {
+  const [tasks, setTasks] = useState([]);
+  const [newTask, setNewTask] = useState('');
+
+  const addTask = () => {
+    if (newTask.trim() === '') return;
+    const task = {
+      text: newTask,
+      completed: false,
+      date: new Date().toLocaleDateString()
+    };
+    setTasks([...tasks, task]);
+    setNewTask('');
+  };
+
+  const toggleTask = (index) => {
+    const updated = tasks.map((t, i) => i === index ? { ...t, completed: !t.completed } : t);
+    setTasks(updated);
+  };
+
+  const removeTask = (index) => {
+    const updated = tasks.filter((_, i) => i !== index);
+    setTasks(updated);
+  };
+
+  const groupedTasks = tasks.reduce((groups, task, index) => {
+    const group = groups[task.date] || [];
+    group.push({ ...task, index });
+    groups[task.date] = group;
+    return groups;
+  }, {});
+
+  return (
+    <div className="app">
+      <h1>TaskBuddy</h1>
+      <div className="new-task">
+        <input
+          type="text"
+          value={newTask}
+          placeholder="Add a task"
+          onChange={(e) => setNewTask(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && addTask()}
+        />
+        <button onClick={addTask}>Add</button>
+      </div>
+      <div className="task-groups">
+        {Object.entries(groupedTasks).map(([date, items]) => (
+          <div key={date} className="task-group">
+            <div className="task-group-header">{date}</div>
+            <ul className="task-list">
+              {items.map((task) => (
+                <li key={task.index} className={task.completed ? 'completed' : ''}>
+                  <input
+                    type="checkbox"
+                    checked={task.completed}
+                    onChange={() => toggleTask(task.index)}
+                  />
+                  <span>{task.text}</span>
+                  <button onClick={() => removeTask(task.index)}>X</button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,11 @@
+/* Global styles */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Roboto', sans-serif;
+  background: linear-gradient(135deg, #ece9e6, #ffffff);
+  margin: 0;
+  padding: 20px;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- group tasks by date and display a sticky header for each day
- style new date headers
- document the grouping behavior in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684196b724148330b60bb68e8719714e